### PR TITLE
my_help_opsions

### DIFF
--- a/lib/my_help.rb
+++ b/lib/my_help.rb
@@ -38,9 +38,9 @@ module MyHelp
           opt.version = MyHelp::VERSION
           puts opt.ver
         }
-        opt.on('-l', '--list', 'list specific helps'){list_helps}
-        opt.on('-e NAME', '--edit NAME', 'edit NAME help(eg test_help)'){|file| edit_help(file)}
-        opt.on('-i NAME', '--init NAME', 'initialize NAME help(eg test_help)'){|file| init_help(file)}
+        opt.on('-l', '--list', '個別(specific)ヘルプのList表示.'){list_helps}
+        opt.on('-e NAME', '--edit NAME', 'NAME(例：test_help)をEdit編集.'){|file| edit_help(file)}
+        opt.on('-i NAME', '--init NAME', 'NAME(例：test_help)のtemplateを作成.'){|file| init_help(file)}
         opt.on('-m', '--make', 'make executables for all helps'){make_help}
         opt.on('-c', '--clean', 'clean up exe dir.'){clean_exe_dir}
         opt.on('--install_local','install local after edit helps'){install_local}


### PR DESCRIPTION

READMEファイルでは

Usage: my_help [options]
    -v, --version                    show program Version.
    -l, --list                       個別(specific)ヘルプのList表示.
    -e, --edit NAME                  NAME(例：test_help)をEdit編集.
    -i, --init NAME                  NAME(例：test_help)のtemplateを作成.
    -m, --make                       make executables for all helps.
    -c, --clean                      clean up exe dir.
        --install_local              install local after edit helps
        --delete NAME                delete NAME help

と日本語混じりの内容なのに，実際は

Usage: my_help [options]
    -v, --version                    show program Version.
    -l, --list                       list specific helps
    -e, --edit NAME                  edit NAME help(eg test_help)
    -i, --init NAME                  initialize NAME help(eg test_help)
    -m, --make                       make executables for all helps
    -c, --clean                      clean up exe dir.
        --install_local              install local after edit helps
        --delete NAME                delete NAME help

とmy_helpのoption英語だけだったのが気になったので
READMEに合わせて変えてみました．

このようなところしか見つけられなくてすいません．
