### PR TITLE
repair README

### DIFF
--- a/.ipynb_checkpoints/README-checkpoint.ipynb
+++ b/.ipynb_checkpoints/README-checkpoint.ipynb
@@ -125,6 +125,8 @@
     "\n",
     "でmy_help.gemspecに記述されている必要なgemsがbundleされます．\n",
     "\n",
+    "Could not locate Gemfileとエラーが出た場合は、Gemfileのある場所を探し、その配下に移動してから再びコマンドを入力する．\n",
+    "\n",
     "用意されているコマンドは，\n",
     "\n",
     "```\n",

--- a/README.ipynb
+++ b/README.ipynb
@@ -125,6 +125,8 @@
     "\n",
     "でmy_help.gemspecに記述されている必要なgemsがbundleされます．\n",
     "\n",
+    "Could not locate Gemfileとエラーが出た場合は、Gemfileのある場所を探し、その配下に移動してから再びコマンドを入力する．\n",
+    "\n",
     "用意されているコマンドは，\n",
     "\n",
     "```\n",


### PR DESCRIPTION
READMEに以下の文を追記しました．

「Could not locate Gemfileとエラーが出た場合は、Gemfileのある場所を探し、その配下に移動してから再びコマンドを入力する．」
