### PR TITLE
remove setup from version in my_help.rb

### DIFF
--- a/lib/my_help.rb
+++ b/lib/my_help.rb
@@ -1,90 +1,97 @@
 # -*- coding: utf-8 -*-
-require 'thor'
-require 'command_line/global'
-require 'colorize'
+require "thor"
+require "command_line/global"
+require "colorize"
 
-require 'my_help_list'
-require 'my_help/version'
-require 'my_help/my_help_controll'
-require 'my_help/tomo_help_controll'
-require 'my_help/org2yml'
+require "my_help_list"
+require "my_help/version"
+require "my_help/my_help_controll"
+require "my_help/tomo_help_controll"
+require "my_help/org2yml"
 # Add requires for other files you add to your project here, so
 # you just need to require this one file in your bin file
 
 module MyHelp
   class CLI < Thor
-    desc('setup', 'set up the test database')
+    desc("setup", "set up the test database")
+
     def setup(*args)
-      puts "my_help called with '%s'" % args.join(' ')
+      puts "my_help called with '%s'" % args.join(" ")
       $control = Control.new
     end
 
-    desc 'version', 'show version'
+    desc "version", "show version"
+
     def version
-      invoke :setup
+      #invoke :setup
       puts VERSION
     end
 
-    desc 'set_editor EDITOR_NAME', 'set editor to EDITOR_NAME'
+    desc "set_editor EDITOR_NAME", "set editor to EDITOR_NAME"
+
     def set_editor(editor_name)
       invoke :setup
       $control.set_editor(editor_name)
     end
 
-    desc 'edit HELP', 'edit HELP'
+    desc "edit HELP", "edit HELP"
+
     def edit(help_name)
       invoke :setup
       $control.edit_help(help_name)
     end
 
-    desc 'new HELP', 'make new HELP'
+    desc "new HELP", "make new HELP"
+
     def new(help_name)
       invoke :setup
       $control.init_help(help_name)
     end
 
-    desc 'delete HELP', 'delete HELP'
+    desc "delete HELP", "delete HELP"
+
     def delete(help_name)
       invoke :setup
       $control.delete_help(help_name)
     end
 
-    desc 'git [push|pull]', 'git push or pull'
+    desc "git [push|pull]", "git push or pull"
+
     def git(push_or_pull, *args)
       p push_or_pull
       invoke :setup
       argument_size = args.size
       Dir.chdir($control.local_help_dir) do
         case push_or_pull
-        when 'push'
+        when "push"
           if argument_size == 0
-            comms = ['git add -A',
+            comms = ["git add -A",
                      "git commit -m 'git push from my_help'",
-                     'git push origin main']
+                     "git push origin main"]
           else
             p args
             argument_size.times do |i|
-              orgfile = args[i] + '.org'
+              orgfile = args[i] + ".org"
               file = File.join($control.local_help_dir, orgfile)
               if File.exist?(file) == true
                 puts orgfile.green
                 dir = $control.local_help_dir
                 Dir.chdir(dir) do
-                  comm = 'git add ' + file
+                  comm = "git add " + file
                   puts c
                   c = command_line(comm)
                   puts c.stdout.blue
                   puts c.stderr.red
                 end
               else
-                puts (orgfile + ' does not existed').red
+                puts (orgfile + " does not existed").red
               end
             end
             comms = ["git commit -m 'git push from my_help'",
-                     'git push origin main']
+                     "git push origin main"]
           end
-        when 'pull'
-          comms = ['git pull']
+        when "pull"
+          comms = ["git pull"]
         else
           raise "my_help git was called by the other than 'push or pull'"
         end
@@ -96,6 +103,7 @@ module MyHelp
         end
       end
     end
+
     #  desc "search {find_char}", "search FIND_CHAR"
     #  def search(find_char)
     #    invoke :setup

--- a/test/my_help_test.rb
+++ b/test/my_help_test.rb
@@ -60,4 +60,11 @@ class MyHelpTest < Test::Unit::TestCase
       assert_equal expected, Control.new(conf_path).show_item("todo", "-d")
     end
   end
+
+  sub_test_case "Version" do
+    test "show version" do
+      expected = "0.9.0"
+      assert_equal expected, VERSION
+    end
+  end
 end


### PR DESCRIPTION
invoke :setupはdef versionで使われていないため，消したらどうでしょうか．