### PR TITLE
Ha88te update

### DIFF
--- a/lib/my_help/my_help_controll.rb
+++ b/lib/my_help/my_help_controll.rb
@@ -1,21 +1,15 @@
 # -*- coding: utf-8 -*-
-<<<<<<< HEAD
 require "fileutils"
 require "yaml"
 require_relative "./config"
-=======
-require 'fileutils'
-require 'yaml'
-require_relative './config'
-require_relative './my_help_list'
->>>>>>> ab1dd5fac33b3b947504ddda5616e37ebf849be2
+require_relative "./my_help_list"
 
 module MyHelp
   WrongFileName = Class.new(RuntimeError)
 
   class Control
     include MyHelpList
-    
+
     attr_accessor :local_help_dir, :editor
 
     def initialize(conf_path = nil)
@@ -64,20 +58,9 @@ module MyHelp
     end
 
     def list_help(file)
-<<<<<<< HEAD
       file_path = File.join(@conf[:local_help_dir], file + ".org")
-      output = ""
-      begin
-        help = auto_load(file_path)
-        help.each_pair do |key, conts|
-          output << conts[:cont] if key == :head
-          output << disp_opts(conts[:opts])
-        end
-=======
-      file_path=File.join(@conf[:local_help_dir],file+'.org')
       begin
         output = help_list(file_path)
->>>>>>> ab1dd5fac33b3b947504ddda5616e37ebf849be2
       rescue
         raise WrongFileName,
               "No help named '#{file}' in '#{@conf[:local_help_dir]}'."
@@ -110,15 +93,17 @@ module MyHelp
       end
     end
 
-    def init_help(file)
+    def init_help(file = nil)
       if file.nil?
         puts "specify NAME".red
-        exit
+        #exit
+        return
       end
       p target_help = File.join(@conf[:local_help_dir], file + ".org")
       if File::exists?(target_help)
         puts "File exists. delete it first to initialize it."
-        exit
+        #exit
+        return
       end
       p template = File.join(@conf[:template_dir], "help_template.org")
       FileUtils::Verbose.cp(template, target_help)
@@ -189,21 +174,5 @@ module MyHelp
       }
       return entries
     end
-
-<<<<<<< HEAD
-    def auto_load(file_path)
-      case File.extname(file_path)
-      #      when '.yml'
-      #        cont = YAML.load(File.read(file_path))
-      when ".org"
-        cont = OrgToYaml.new(file_path).help_cont
-      else
-        puts "Not handling file types of #{file_path}"
-        cont = nil
-      end
-      cont
-    end
-=======
->>>>>>> ab1dd5fac33b3b947504ddda5616e37ebf849be2
   end
 end

--- a/test/.my_help/my_help_test.org
+++ b/test/.my_help/my_help_test.org
@@ -1,0 +1,8 @@
+#+STARTUP: indent nolineimages
+* head
+- ヘルプのサンプル雛形
+-   headに常に表示される内容を記述
+* license
+-      cc by Shigeto R. Nishitani, 2016
+* item_example
+- itemの例

--- a/test/my_help_test.rb
+++ b/test/my_help_test.rb
@@ -78,9 +78,34 @@ class MyHelpTest < Test::Unit::TestCase
 
   sub_test_case "Edit Help" do
     test "edit_help" do
-      expected = 
-      conf_path = File.join(Dir.pwd, "test")
-      assert_equal expected, Control.new(conf_path).edit_help("my_help_test")
+
+      puts "
+            システムコールが呼ばれているのでテストできません．
+            edit_helpでは，thorでmy_help_test.orgなどが呼ばれたときに，呼ばれるものである．
+            そうするとtarget_helpにいき，それがlocal_help_entries.memberかを見て，
+            memberの時にはシステムコールがされる．
+            ところがこれをtestすることはできない為，今は先送りしています．
+            "
+     # expected = target_help
+     # conf_path = File.join(Dir.pwd, "test")
+     # assert_equal expected, Control.new(conf_path).edit_help("my_help_test")
     end
+  end
+
+ 
+  sub_test_case "Local Help Entries" do
+    test "init_help" do
+      conf_path = File.join(Dir.pwd, "test")
+      puts Control.new(conf_path).init_help("my_help_test")
+    end
+    test "init_help without argument(引数)" do
+      conf_path = File.join(Dir.pwd, "test")
+      puts Control.new(conf_path).init_help()
+    end
+    test "edit_help" do
+      conf_path = File.join(Dir.pwd, "test")
+#      puts Control.new(conf_path).edit_help("my_help_test")
+    end
+    
   end
 end


### PR DESCRIPTION
my_help_controll.rbのメソッドinit_helpでexitが用いられていた為，file=nilの場合のtestが動きませんでした．
その為，exitをreturnに変えました．
rake testすると，
Error: test: init_help without argument(引数)(MyHelpTest::Local Help Entries): ArgumentError: wrong number of arguments (given 0, expected 1)
のようなエラーが返ってきました．
fileがnilの場合だとそこで止まってしまう為，そもそもinit_helpの引数部分をfile=nilにするように変えることで，rake testが通るようになりました．